### PR TITLE
Feature - Spoiler Text

### DIFF
--- a/YuYuYu.css
+++ b/YuYuYu.css
@@ -56,7 +56,7 @@ a[href="/s"]::after, a[href="#s"]::after,
 }
 a[href="/s"]:hover, a[href="#s"]:hover,
 .md p > a[href="/s"]:hover, a[href="#s"]:hover {
-	color: #fa0 !important;
+	color: #b62e2e !important;
 }
 a[href="/s"]:hover::after, a[href="#s"]:hover::after,
 a[href="/s"]:active::after, a[href="#s"]:active::after,

--- a/YuYuYu.css
+++ b/YuYuYu.css
@@ -38,7 +38,7 @@
 
 ==================================================================================================================================*/
 
-/* Text Spoilers */
+/* --- Addon: Spoiler Tags --- */
 a[href="/s"], a[href="#s"],
 .md p > a[href="/s"] {
 	text-decoration: none !important;
@@ -64,3 +64,4 @@ a[href="/s"]:active::after, a[href="#s"]:active::after,
 .md p > a[href="/s"]:active::after, a[href="#s"]:active::after {
 	color: #fff;
 }
+/* --- End Addon --- */

--- a/YuYuYu.css
+++ b/YuYuYu.css
@@ -56,7 +56,7 @@ a[href="/s"]::after, a[href="#s"]::after,
 }
 a[href="/s"]:hover, a[href="#s"]:hover,
 .md p > a[href="/s"]:hover, a[href="#s"]:hover {
-	color: #fff !important;
+	color: #fa0 !important;
 }
 a[href="/s"]:hover::after, a[href="#s"]:hover::after,
 a[href="/s"]:active::after, a[href="#s"]:active::after,

--- a/YuYuYu.css
+++ b/YuYuYu.css
@@ -37,3 +37,30 @@
 
 
 ==================================================================================================================================*/
+
+/* Text Spoilers */
+a[href="/s"], a[href="#s"],
+.md p > a[href="/s"] {
+	text-decoration: none !important;
+	cursor: default;
+	background: #000;
+	color: #fff !important;
+	display: inline-block;
+}
+a[href="/s"]::after, a[href="#s"]::after,
+.md p > a[href="/s"]::after {
+	content: attr(title);
+	color: #000;
+	padding: 0 0.5em;
+	visibility: visible;
+}
+a[href="/s"]:hover, a[href="#s"]:hover,
+.md p > a[href="/s"]:hover, a[href="#s"]:hover {
+	color: #fff !important;
+}
+a[href="/s"]:hover::after, a[href="#s"]:hover::after,
+a[href="/s"]:active::after, a[href="#s"]:active::after,
+.md p > a[href="/s"]:hover::after, a[href="#s"]:hover::after,
+.md p > a[href="/s"]:active::after, a[href="#s"]:active::after {
+	color: #fff;
+}


### PR DESCRIPTION
Added spoiler text for Post and Comment body text to hide spoilerific details. Degrades gracefully, and in the event that no CSS is loaded, the spoiler text is only visible via hovering. Syntax allows for /r/anime style spoilers and the recommended non-linking version.

Syntax:
- /r/anime Style: `[Warning](/s "Spoiler here")`
- Non-Linking: `[Warning](#s "Spoiler here")`

![image](https://cloud.githubusercontent.com/assets/7350359/8691402/27f3e562-2a90-11e5-81b6-3733b2c41670.png)
