### PR TITLE
Feature - Post Flairs

### DIFF
--- a/YuYuYu.css
+++ b/YuYuYu.css
@@ -139,3 +139,29 @@ a[href="/s"]:active::after, a[href="#s"]:active::after,
 	color: #fff;
 }
 /* --- End Addon --- */
+/* --- Addon: Post Flairs --- */
+/* Spoiler Titles */
+.linkflair-spoiler .linkflairlabel {
+    background-color:#ad6b68
+}
+.listing-page .linkflair-spoiler a.title {
+    background-color:#ad6b68;
+    color:#ad6b68;
+    text-shadow:none
+}
+.listing-page .linkflair-spoiler a.title:hover {
+    background-color:#ecf0f1!important
+}
+.listing-page .linkflair-spoiler a.title:visited {
+    background-color:#ecf0f1!important;
+    color:#7d5d8a!important
+}
+
+/* Spoiler Images */
+.linkflair-spoiler img {
+    display:none
+}
+.linkflair-spoiler .thumbnail {
+    
+}
+/* --- End Addon --- */

--- a/YuYuYu.css
+++ b/YuYuYu.css
@@ -140,10 +140,17 @@ a[href="/s"]:active::after, a[href="#s"]:active::after,
 }
 /* --- End Addon --- */
 /* --- Addon: Post Flairs --- */
-/* Spoiler Titles */
+/* Post Flair Labels*/
 .linkflair-spoiler .linkflairlabel {
     background-color:#ad6b68
 }
+.linkflair-meta .linkflairlabel {
+    background-color:#ffbc5e
+}
+.linkflair-merch .linkflairlabel {
+    background-color:#ce6dff
+}
+/* Spoiler Titles */
 .listing-page .linkflair-spoiler a.title {
     background-color:#ad6b68;
     color:#ad6b68;


### PR DESCRIPTION
Added Post Flair label Colours:
- Spoiler: #ad6b68
- Meta: #ffbc5e
- Merch: #ce6dff

Added Spoiler Post Title hiding and removed Image Thumbnails for Spoiler Flaired posts.

Hovering the title or already having visited a spoiler post will reveal the title text, but not the Image Thumbnails.

![image](https://cloud.githubusercontent.com/assets/7350359/8887961/4b08ebfe-3267-11e5-80ad-61006db01e3b.png)
