### PR TITLE
Feature: Post flair upgrade

### DIFF
--- a/YuYuYu/Stylesheet/YuYuYu.css
+++ b/YuYuYu/Stylesheet/YuYuYu.css
@@ -261,6 +261,9 @@ a[href="#s"]:active::after {
 .linkflair-merch .linkflairlabel {
     background-color: #ce6dff
 }
+.linkflair-discussion .linkflairlabel {
+    background-color: #23B2FF
+}
 /* Spoiler Titles */
 
 .listing-page .linkflair-spoiler-title a.title {

--- a/YuYuYu/Stylesheet/YuYuYu.css
+++ b/YuYuYu/Stylesheet/YuYuYu.css
@@ -252,7 +252,7 @@ a[href="#s"]:active::after {
 /* --- Addon: Post Flairs --- */
 /* Post Flair Labels*/
 
-.linkflair-spoiler .linkflairlabel {
+.linkflair-spoiler .linkflairlabel, .linkflair-spoiler-title .linkflairlabel {
     background-color: #ad6b68
 }
 .linkflair-meta .linkflairlabel {
@@ -263,21 +263,21 @@ a[href="#s"]:active::after {
 }
 /* Spoiler Titles */
 
-.listing-page .linkflair-spoiler a.title {
+.listing-page .linkflair-spoiler-title a.title {
     background-color: #ad6b68;
     color: #ad6b68;
     text-shadow: none
 }
-.listing-page .linkflair-spoiler a.title:hover {
+.listing-page .linkflair-spoiler-title a.title:hover {
     background-color: #ecf0f1!important
 }
-.listing-page .linkflair-spoiler a.title:visited {
+.listing-page .linkflair-spoiler-title a.title:visited {
     background-color: #ecf0f1!important;
     color: #7d5d8a!important
 }
 /* Spoiler Images */
 
-.linkflair-spoiler img {
+.linkflair-spoiler img, .linkflair-spoiler-title img {
     display: none
 }
 .linkflair-spoiler .thumbnail {}


### PR DESCRIPTION
Adding Level 2 Spoilers (Blocks Titles), and changed current Spoiler flairs into Level 1 (Marked as spoilers and blocking Thumbnails)
Added Discussion flair, which implies spoilers, but denotes the intention of discussing a topic with other users or asking a question.
![image](https://cloud.githubusercontent.com/assets/7350359/9727516/a9cf932a-55cd-11e5-86b2-bac22ca93744.png)
