### PR TITLE
Fix headers not showing up in text post previews again

### DIFF
--- a/YuYuYu/Stylesheet/Modules/Content.scss
+++ b/YuYuYu/Stylesheet/Modules/Content.scss
@@ -8,3 +8,5 @@ body.modtools-page > .content {
   margin: 126px 332px 0 16px;
   padding: 0;
 }
+// Prevent Naut from hiding h1's in the RES text post preview box
+.submit-page .content * h1 { display: block }


### PR DESCRIPTION
Re-submit of #39 but to the right branch and in the right file. Prevents h1 elements in RES text post previews from disappearing thanks to Naut. Fixes #21.
